### PR TITLE
Translation of Chapter 28 & 29

### DIFF
--- a/chapter28.tex
+++ b/chapter28.tex
@@ -8,7 +8,7 @@
 
 %\chapter{Output Routines}\label{output}
 %\index{output routine|(}
-\chapter{Output Routines}\label{output}
+\chapter{输出例程}\label{output}
 \index{output routine|(}
 
 %The final stages of page processing are performed by the
@@ -17,82 +17,78 @@
 %in \cs{box255}. This chapter treats the commands and parameters
 %that pertain to the output routine, and it explains how
 %output routines can receive information through marks.
-The final stages of page processing are performed by the
-output routine. The page builder cuts off a certain portion
-of the main vertical list and hands it to the output routine
-in \cs{box255}. This chapter treats the commands and parameters
-that pertain to the output routine, and it explains how
-output routines can receive information through marks.
+页面处理的最后一步是由输出例程完成的。页面构建器从主竖直列将一部分内容分割处理，并通过 \cs{box255} 将它传递给输出例程。本章介绍与输出例程相关的命令和参数，并解释输出例程如何通过标记 (mark) 接收信息。
+
 
 %\label{cschap:output}\label{cschap:shipout}\label{cschap:mark}\label{cschap:topmark}\label{cschap:botmark}\label{cschap:firstmark}\label{cschap:splitbotmark}\label{cschap:splitfirstmark}\label{cschap:deadcycles}\label{cschap:maxdeadcycles}\label{cschap:outputpenalty2}
 %\begin{inventory}
-%\item [\cs{output}] 
+%\item [\cs{output}]
 %      Token list with instructions for shipping out pages.
 \label{cschap:output}\label{cschap:shipout}\label{cschap:mark}\label{cschap:topmark}\label{cschap:botmark}\label{cschap:firstmark}\label{cschap:splitbotmark}\label{cschap:splitfirstmark}\label{cschap:deadcycles}\label{cschap:maxdeadcycles}\label{cschap:outputpenalty2}
 \begin{inventory}
-\item [\cs{output}] 
-      Token list with instructions for shipping out pages.
+\item [\cs{output}]
+      用于输出页面的包含指令的记号列。
 
-%\item [\cs{shipout}] 
+%\item [\cs{shipout}]
 %      Ship a box to the \n{dvi} file.
-\item [\cs{shipout}] 
-      Ship a box to the \n{dvi} file.
+\item [\cs{shipout}]
+      将一个盒子输出给 \n{dvi} 文件。
 
 
-%\item [\cs{mark}] 
+%\item [\cs{mark}]
 %      Specify a mark text.
-\item [\cs{mark}] 
-      Specify a mark text.
+\item [\cs{mark}]
+      设置一个标记文本。
 
-%\item [\cs{topmark}] 
+
+%\item [\cs{topmark}]
 %      The last mark on the previous page.
-\item [\cs{topmark}] 
-      The last mark on the previous page.
+\item [\cs{topmark}]
+      前一页的最后一个标记。
 
-%\item [\cs{botmark}] 
+%\item [\cs{botmark}]
 %      The last mark on the current page.
-\item [\cs{botmark}] 
-      The last mark on the current page.
+\item [\cs{botmark}]
+      当前页的最后一个标记。
 
-%\item [\cs{firstmark}] 
+%\item [\cs{firstmark}]
 %      The first mark on the current page.
-\item [\cs{firstmark}] 
-      The first mark on the current page.
+\item [\cs{firstmark}]
+      当前页的第一个标记。
 
-%\item [\cs{splitbotmark}] 
+%\item [\cs{splitbotmark}]
 %      The last mark on a split-off page.
-\item [\cs{splitbotmark}] 
-      The last mark on a split-off page.
+\item [\cs{splitbotmark}]
+      一个分割页面上的最后一个标记。
 
-%\item [\cs{splitfirstmark}] 
+%\item [\cs{splitfirstmark}]
 %      The first mark on a split-off page.
-\item [\cs{splitfirstmark}] 
-      The first mark on a split-off page.
+\item [\cs{splitfirstmark}]
+      一个分割页面上的第一个标记。
 
-%\item [\cs{deadcycles}] 
-%      Counter that keeps track of how many times 
-%      the output routine has been called without a \cs{shipout} 
-%      taking place. 
-\item [\cs{deadcycles}] 
-      Counter that keeps track of how many times 
-      the output routine has been called without a \cs{shipout} 
-      taking place. 
+%\item [\cs{deadcycles}]
+%      Counter that keeps track of how many times
+%      the output routine has been called without a \cs{shipout}
+%      taking place.
+\item [\cs{deadcycles}]
+      计数器用于追踪调用输出例程但不进行 \cs{shipout} 的次数。
 
-%\item [\cs{maxdeadcycles}] 
+
+%\item [\cs{maxdeadcycles}]
 %      The maximum number of times that the output routine is allowed to
 %      be called without a \cs{shipout} occurring.
-\item [\cs{maxdeadcycles}] 
-      The maximum number of times that the output routine is allowed to
-      be called without a \cs{shipout} occurring.
+\item [\cs{maxdeadcycles}]
+      允许调用输出例程但不进行 \cs{shipout} 的最大次数。
 
-%\item [\cs{outputpenalty}] 
+
+%\item [\cs{outputpenalty}]
 %      Value of the penalty at the current page break,
 % \alt
 %      or $10\,000$ if the break was not at a penalty.
-\item [\cs{outputpenalty}] 
-      Value of the penalty at the current page break,
+\item [\cs{outputpenalty}]
+      当前页面分页的惩罚值
  \alt
-      or $10\,000$ if the break was not at a penalty.
+      或者当分页点不在惩罚处则为$10\,000$。
 
 %\end{inventory}
 \end{inventory}
@@ -101,39 +97,36 @@ output routines can receive information through marks.
 %%\point The \cs{output} token list
 %\section{The \protect\cs{output} token list}
 %\point The \cs{output} token list
-\section{The \protect\cs{output} token list}
+\section{\protect\cs{output} 记号列}
 
 %Common parlance has it that
 %`the output routine is called' when \TeX\ has found a place
 %to break the main vertical list.
 %Actually, \cs{output} is not a macro but a token list that
 %is inserted into \TeX's command stream.
-Common parlance has it that
-`the output routine is called' when \TeX\ has found a place
-to break the main vertical list.
-Actually, \cs{output} is not a macro but a token list that
-is inserted into \TeX's command stream.
+
+一般来说，当 \TeX\ 找到一个从主竖直列分割的断点时，输出例程将被调用。实际上，
+\cs{output} 不是一个宏，而是一个插入 \TeX 命令流中的记号列。
+
 
 %Insertion of the \cs{output} token list happens
 %\cstoidx output\par
 %inside a group that is implicitly opened.
 %Also, \TeX\ enters internal vertical mode.
-%Because of the group, non-local assignments 
+%Because of the group, non-local assignments
 %(to the page number, for instance)
 %have to be prefixed with \cs{global}.
-%The vertical mode implies that during the workings of the 
-%output routine 
+%The vertical mode implies that during the workings of the
+%output routine
 %spaces are mostly harmless.
-Insertion of the \cs{output} token list happens
+
+\cs{output} 记号列的插入发生在
 \cstoidx output\par
-inside a group that is implicitly opened.
-Also, \TeX\ enters internal vertical mode.
-Because of the group, non-local assignments 
-(to the page number, for instance)
-have to be prefixed with \cs{global}.
-The vertical mode implies that during the workings of the 
-output routine 
-spaces are mostly harmless.
+一个隐式开放的编组中。
+同时 \TeX\  进入内部竖直模式。
+因为编组，所有的非局部赋值(比如页码)都需要加上\cs{global}。
+竖直模式意味着在输出例程工作过程中空格是无害的。
+
 
 %The \cs{output} token list belongs
 %to the class of the
@@ -142,17 +135,16 @@ spaces are mostly harmless.
 %Assigning an output routine can therefore take the following
 %forms:
 %\begin{disp}\cs{output}\gr{equals}\gr{general text}\quad
-%or\quad 
+%or\quad
 %\cs{output}\gr{equals}\gr{filler}\gr{token variable}
 %\end{disp}
-The \cs{output} token list belongs
-to the class of the
-\gr{token parameter}s. These behave the same as
-\cs{toks}$nnn$ token lists; see Chapter~\ref{token}.
-Assigning an output routine can therefore take the following
-forms:
+
+\cs{output} 记号列属于 \gr{token parameter} 类。其机制与\cs{toks}$nnn$ 记号列(见第\ref{token}章) 完全相同。
+
+因此给输出例程赋值可以采用如下形式：
+
 \begin{disp}\cs{output}\gr{equals}\gr{general text}\quad
-or\quad 
+or\quad
 \cs{output}\gr{equals}\gr{filler}\gr{token variable}
 \end{disp}
 
@@ -161,39 +153,31 @@ or\quad
 %\section{Output and \protect\cs{box255}}
 %\label{output255}
 %\point[output255] Output and \cs{box255}
-\section{Output and \protect\cs{box255}}
+\section{输出和 \protect\cs{box255}}
 \label{output255}
 
 %\TeX's page builder breaks the current page at the optimal point,
 %and stores everything above that in \cs{box255};
 %then, the \cs{output} tokens are inserted into the input stream.
 %Any remaining material on the main vertical list
-%is pushed back to the recent 
-%contributions. 
+%is pushed back to the recent
+%contributions.
 %If the page is broken at a penalty,
 %\alt
-%that value is recorded in \cs{outputpenalty}, and 
+%that value is recorded in \cs{outputpenalty}, and
 %a penalty of size $10\,000$ is placed on top of the
 %recent contributions; otherwise, \cs{outputpenalty}
 %is set to~$10\,000$.
 %When the output routine is finished, \cs{box255} is
 %supposed to be empty.
 %If it is not, \TeX\ gives an error message.
-\TeX's page builder breaks the current page at the optimal point,
-and stores everything above that in \cs{box255};
-then, the \cs{output} tokens are inserted into the input stream.
-Any remaining material on the main vertical list
-is pushed back to the recent 
-contributions. 
-If the page is broken at a penalty,
+
+
+\TeX 的页面构建器在一个最优点把当前页分割出来，并将其保持在 \cs{box255} 中，然后 \cs{output} 记号将被插入到输入流中。主竖直列中的剩余部分将退回到“备选内容”中。如果是在一个惩罚处分页，
 \alt
-that value is recorded in \cs{outputpenalty}, and 
-a penalty of size $10\,000$ is placed on top of the
-recent contributions; otherwise, \cs{outputpenalty}
-is set to~$10\,000$.
-When the output routine is finished, \cs{box255} is
-supposed to be empty.
-If it is not, \TeX\ gives an error message.
+则该惩罚值将在 \cs{outputpenalty} 中记录下来，同时将一个 值为$10\,000$的惩罚值放在“备选内容”顶部，否则 \cs{outputpenalty} 设置为 $10\,000$ 。
+当输出例程完成， \cs{box255} 应该为空，若不为空， \TeX\ 给出一个错误提示。
+
 
 %Usually, the output routine will take the pagebox,
 %\cstoidx shipout\par
@@ -204,7 +188,7 @@ If it is not, \TeX\ gives an error message.
 %and ship the page to the \n{dvi} file:
 %\begin{verbatim}
 %\output={\setbox255=\vbox
-%           {\someheadline 
+%           {\someheadline
 %            \vbox to \vsize{\unvbox255 \unvbox\footins}
 %            \somefootline}
 %         \shipout\box255}
@@ -215,26 +199,24 @@ If it is not, \TeX\ gives an error message.
 %smaller height.
 %Thus, the above output routine may lead to underfull boxes.
 %This can be remedied with a \cs{vfil}.
-Usually, the output routine will take the pagebox,
+
+通常，输出例程将包含页面盒子，
 \cstoidx shipout\par
 \mdqon
-append a headline and/""or footline,
+以及一个页面和/或页脚,
 \mdqoff
-maybe merge in some insertions such as footnotes,
-and ship the page to the \n{dvi} file:
+可能也将融入一些插入项比如脚注，然后将页面输出给 \n{dvi} 文件：
+
 \begin{verbatim}
 \output={\setbox255=\vbox
-           {\someheadline 
+           {\someheadline
             \vbox to \vsize{\unvbox255 \unvbox\footins}
             \somefootline}
          \shipout\box255}
 \end{verbatim}
-When box 255 reaches the output routine, its height has
-been set to \cs{vsize}.
-However, the material in it can have considerably
-smaller height.
-Thus, the above output routine may lead to underfull boxes.
-This can be remedied with a \cs{vfil}.
+
+当盒子255 到达输出例程时，它的高度已设置为 \cs{vsize}。然而其中的内容的高度可能会小很多。因此上述输出例程可能导致未充满的盒子，这可以通过一个 \cs{vfil} 进行修补。
+
 
 %The output routine is under no obligation to
 %\cstoidx deadcycles\par
@@ -243,17 +225,13 @@ This can be remedied with a \cs{vfil}.
 %break. The number of times
 %that the output routing  postpones the \cs{shipout}
 %is recorded in \cs{deadcycles}: this parameter is set to~0
-%by \cs{shipout}, and increased by~1 just before 
+%by \cs{shipout}, and increased by~1 just before
 %every \cs{output}.
-The output routine is under no obligation to
+
+输出历程没有义务来帮助处理 \cs{box255} ，
 \cstoidx deadcycles\par
-do anything useful with \cs{box255}; it can empty it, or
-unbox it to let \TeX\ have another go at finding a page
-break. The number of times
-that the output routing  postpones the \cs{shipout}
-is recorded in \cs{deadcycles}: this parameter is set to~0
-by \cs{shipout}, and increased by~1 just before 
-every \cs{output}.
+但它可以清空它或者解包它，让 \TeX\ 再次寻找一个分页点。输出例程推迟 \cs{shipout} 的次数记录在 \cs{deadcycles}中： 这一参数由 \cs{shipout} 重置为0，而在每个 \cs{output} 前增加 1。
+
 
 %When  the number of dead cycles reaches
 %\csidx{maxdeadcycles}, \TeX\ gives an error message,
@@ -267,27 +245,23 @@ every \cs{output}.
 %than plain \TeX, because the output routine in \LaTeX\
 %is often called for
 %intermediate handling of floats and marginal notes.
-When  the number of dead cycles reaches
-\csidx{maxdeadcycles}, \TeX\ gives an error message,
-and performs the default output routine
+
+当推迟输出的次数达到 \csidx{maxdeadcycles} ， \TeX\ 给出一个错误警告，并执行默认的输出例程：
+
 \begin{verbatim}
 \shipout\box255
 \end{verbatim}
-instead of the routine it was about
-to start.
-The \LaTeX\ format has a much higher value for \cs{maxdeadcycles}
-than plain \TeX, because the output routine in \LaTeX\
-is often called for
-intermediate handling of floats and marginal notes.
+
+代替将要开始的输出过程。 \LaTeX\  格式有比 plain \TeX 更高的 \cs{maxdeadcycles} 值，因为在 \LaTeX\ 中的输出例程经常会被调用来处理浮动体和边注。
+
 
 %The \cs{shipout} command can send any \gr{box} to the \n{dvi} file;
 %this need not be box 255, or even a box
 %containing the current page.
 %It does not have to be called inside the output routine, either.
-The \cs{shipout} command can send any \gr{box} to the \n{dvi} file;
-this need not be box 255, or even a box
-containing the current page.
-It does not have to be called inside the output routine, either.
+
+\cs{shipout} 命令可以输出任意的 \gr{box} 到 \n{dvi} 文件，不一定是 box 255 乃至包含当前页面的盒子。它也不一定要在输出例程内调用。
+
 
 %If the output routine produces any material, for instance
 %by calling
@@ -296,61 +270,58 @@ It does not have to be called inside the output routine, either.
 %\end{verbatim}
 %this is put on top
 %of the recent contributions.
-If the output routine produces any material, for instance
-by calling
+如果输出例程产生了任意内容，例如调用：
+
 \begin{verbatim}
 \unvbox255
 \end{verbatim}
-this is put on top
-of the recent contributions.
+
+它将被放到“备选内容”的顶部。
+
 
 %After the output routine finishes, the page builder is
 %activated. In particular, because the current page
 %has been emptied, the \cs{vsize} is read again.
 %Changes made to this parameter inside the output
 %routine (using \cs{global}) will therefore take effect.
-After the output routine finishes, the page builder is
-activated. In particular, because the current page
-has been emptied, the \cs{vsize} is read again.
-Changes made to this parameter inside the output
-routine (using \cs{global}) will therefore take effect.
+输出例程结束后，页面构建器就会激活。特别的，因为当前页面已经清空，\cs{vsize} 会再次读入。因此在输出例程内对该参数做修改(使用 \cs{global})将会生效。
+
 
 %%\point Marks
 %\section{Marks}
 %\point Marks
-\section{Marks}
+\section{标记}
 
 %Information can be passed to the output routine through the
 %\cstoidx mark\par
 %mechanism of \indexterm{marks}. The user can specify a token list
-%with 
+%with
 %\begin{disp}\cs{mark}\lb\gr{mark text}\rb\end{disp}
 %which is put in a mark item on the current vertical list.
 %The mark text is subject to expansion as in \cs{edef}.
-Information can be passed to the output routine through the
+一些信息可以通过标记(\indexterm{marks})机制传递给输出例程。
 \cstoidx mark\par
-mechanism of \indexterm{marks}. The user can specify a token list
-with 
+用户可以设置一个记号列表：
+
 \begin{disp}\cs{mark}\lb\gr{mark text}\rb\end{disp}
-which is put in a mark item on the current vertical list.
-The mark text is subject to expansion as in \cs{edef}.
+
+这将会把一个标记项放入当前竖直列。标记内容将做类似 \cs{edef} 命令中的展开。
+
 
 %If the mark is given in horizontal mode it migrates to
 %the surrounding vertical lists like an insertion item
 %(see page~\pageref{migrate});
 %however, if this is not the external vertical list, the
 %output routine will not find the mark.
-If the mark is given in horizontal mode it migrates to
-the surrounding vertical lists like an insertion item
-(see page~\pageref{migrate});
-however, if this is not the external vertical list, the
-output routine will not find the mark.
+
+如果标记以水平模式给出，将会移入一个类似于插入项的竖直列(见第 ~\pageref{migrate} 页)。然而它不是一个外部竖直列，输出例程将无法发现该标记。
+
 
 %Marks are the main mechanism through which the output routine
 %can obtain information about the contents of the currently
 %broken-off page, in particular its top and bottom.
 %\TeX\ sets three variables:
-%\begin{description} 
+%\begin{description}
 %\item [\csidx{botmark}]
 %   the last mark occurring on the current page;
 %\item [\csidx{firstmark}]
@@ -361,38 +332,33 @@ output routine will not find the mark.
 %   on the previous page.
 %\end{description}
 %If no marks have occurred yet, all three are empty;
-%if no marks occurred on the current page, 
+%if no marks occurred on the current page,
 %all three mark variables are equal
 %to the \cs{botmark} of the previous page.
-Marks are the main mechanism through which the output routine
-can obtain information about the contents of the currently
-broken-off page, in particular its top and bottom.
-\TeX\ sets three variables:
-\begin{description} 
+
+标记是输出例程获取关于当前分页的内容信息特别是顶部和底部信息的主要机制。
+\TeX\ 设置三个参数:
+\begin{description}
 \item [\csidx{botmark}]
-   the last mark occurring on the current page;
+   出现在当前页的最后一个标记;
 \item [\csidx{firstmark}]
-   the first mark occurring on the current page;
+   出现在当前页的第一个标记;
 \item [\csidx{topmark}]
-   the last mark of the previous page,
-   that is, the value of \cs{botmark}
-   on the previous page.
+   前一页的最后一个标记，即前一页的\cs{botmark}值。
 \end{description}
-If no marks have occurred yet, all three are empty;
-if no marks occurred on the current page, 
-all three mark variables are equal
-to the \cs{botmark} of the previous page.
+
+如果没有任何标记，那么三个参数为空。如果当前页面没有标记，那么三个标记等价于前一页的最后一个标记 \cs{botmark}。
+
 
 %For boxes generated by a \cs{vsplit} command (see previous chapter),
 %the \cs{splitbotmark} and \cs{splitfirstmark}
 %\cstoidx splitbotmark\par\cstoidx splitfirstmark\par
 %contain the marks of the split-off part; \cs{firstmark}
 %and \cs{botmark} reflect the state of what remains in the register.
-For boxes generated by a \cs{vsplit} command (see previous chapter),
-the \cs{splitbotmark} and \cs{splitfirstmark}
+对于由 \cs{vsplit} 命令(见前一章)生成的盒子， \cs{splitbotmark} 和 \cs{splitfirstmark}
 \cstoidx splitbotmark\par\cstoidx splitfirstmark\par
-contain the marks of the split-off part; \cs{firstmark}
-and \cs{botmark} reflect the state of what remains in the register.
+包含有分割出来的部分的标记。
+\cs{firstmark}和 \cs{botmark} 反应了寄存器中剩余内容的状态。
 
 %\begin{example} Marks can be used to get a section heading into
 %\howto Do tricks with headlines\par
@@ -404,14 +370,15 @@ and \cs{botmark} reflect the state of what remains in the register.
 %\def\leftheadline{\hbox to \hsize
 %   {\headlinefont \pagenumber\hfil\firstmark}}
 %\end{verbatim}
-%This places the title of the first section that starts on a 
+%This places the title of the first section that starts on a
 %left page in the left headline, and the title of the last section
 %that starts on the right page in the right headline.
 %Placing the headlines on the page is the job of the output routine;
 %see below.
-\begin{example} Marks can be used to get a section heading into
+\begin{example}
+标记可以用来获得章节的标题信息来生成页面的页眉和页脚：
 \howto Do tricks with headlines\par
-the headline or footline of the page.
+
 \begin{verbatim}
 \def\section#1{ ... \mark{#1} ... }
 \def\rightheadline{\hbox to \hsize
@@ -419,11 +386,8 @@ the headline or footline of the page.
 \def\leftheadline{\hbox to \hsize
    {\headlinefont \pagenumber\hfil\firstmark}}
 \end{verbatim}
-This places the title of the first section that starts on a 
-left page in the left headline, and the title of the last section
-that starts on the right page in the right headline.
-Placing the headlines on the page is the job of the output routine;
-see below.
+
+将从左页开始的第一节的标题作为页眉左部，将从右页开始的最后一节的标题放入页眉右部。将页眉放入页面时输出例程的工作，见下面内容。
 
 %It is important that no page breaks can occur in between the
 %mark and the box that places the title:
@@ -437,8 +401,8 @@ see below.
 %    \noindent}
 %\end{verbatim}
 %\end{example}
-It is important that no page breaks can occur in between the
-mark and the box that places the title:
+重要的一点是在标记和放置标题的盒子之间不会出现分页：
+
 \begin{verbatim}
 \def\section#1{ ...
     \penalty\beforesectionpenalty
@@ -457,33 +421,32 @@ mark and the box that places the title:
 %\begin{verbatim}
 %\def\endofchapter
 %\chapter#1{ ... \def\chtitle{#1}\mark{1}\mark{0} ... }
-%\def\theheadline{\expandafter\ifx\firstmark1 
+%\def\theheadline{\expandafter\ifx\firstmark1
 %    \else \chapheadline \fi}
 %\end{verbatim}
 %Only on the page where a chapter starts will the mark be~1,
 %and on all other pages a headline is placed.
-Let us consider
-another example with headlines: often a page looks better if
-the headline is omitted on pages where a chapter starts.
-This can be implemented as follows:
+
+让我们考虑另一个页眉的例子：在章节开始页不显示页眉通常会更好，这可以实现如下：
+
 \begin{verbatim}
 \def\endofchapter
 \chapter#1{ ... \def\chtitle{#1}\mark{1}\mark{0} ... }
-\def\theheadline{\expandafter\ifx\firstmark1 
+\def\theheadline{\expandafter\ifx\firstmark1
     \else \chapheadline \fi}
 \end{verbatim}
-Only on the page where a chapter starts will the mark be~1,
-and on all other pages a headline is placed.
+只有当章节开始时标记才是1，因而所有的其它页中将会放置页眉。
+
 
 %%\point Assorted remarks
 %\section{Assorted remarks}
 %\point Assorted remarks
-\section{Assorted remarks}
+\section{注意点}
 
 %%\spoint Hazards in non-trivial output routines
 %\subsection{Hazards in non-trivial output routines}
 %\spoint Hazards in non-trivial output routines
-\subsection{Hazards in non-trivial output routines}
+\subsection{输出例程中的意外}
 
 %If the final call to the output routine does not
 %perform a \cs{shipout}, \TeX\ will call the output
@@ -491,28 +454,24 @@ and on all other pages a headline is placed.
 %the vertical list is empty, and \cs{deadcycles}
 %is zero. The output routine can set \cs{deadcycles}
 %to zero to prevent this.
-If the final call to the output routine does not
-perform a \cs{shipout}, \TeX\ will call the output
-routine endlessly, since a run will only stop if both
-the vertical list is empty, and \cs{deadcycles}
-is zero. The output routine can set \cs{deadcycles}
-to zero to prevent this.
+
+如果最后一次调用输出例程不能执行\cs{shipout}，那么 \TeX\  将会无限死循环，因为只有当两个竖直列全为空才能停止，且 \cs{deadcycles} 为0。输出例程可以设置 \cs{deadcycles} 为0来阻止
+\footnote{译者注：这里可能有笔误，应是\cs{maxdeadcycles}}。
+
 
 %%\spoint Page numbering
 %\subsection{Page numbering}
 %\index{page!numbering|(}
 %\spoint Page numbering
-\subsection{Page numbering}
+\subsection{页码}
 \index{page!numbering|(}
 
 %The page number is not an intrinsic property of the output
 %routine; in plain \TeX\ it is  the value of \cs{count0}.
 %The output routine is responsible for increasing the
 %page number when a shipout of a  page occurs.
-The page number is not an intrinsic property of the output
-routine; in plain \TeX\ it is  the value of \cs{count0}.
-The output routine is responsible for increasing the
-page number when a shipout of a  page occurs.
+页码不是输出例程的内在属性，在 plain \TeX\ 中它是 \cs{count0} 的值。输出例程负责在执行shipout时增加它。
+
 
 %Apart from   \cs{count0}, counter registers~1--9 are also used
 %for page identification: at shipout \TeX\ writes the values
@@ -522,20 +481,16 @@ page number when a shipout of a  page occurs.
 %a higher number exists, that is, if \cs{count0}${}=1$ and
 %\cs{count3}${}=5$ are the only non-zero counters, the
 %displayed list of counters is~\n{[1.0.0.5]}.
-Apart from   \cs{count0}, counter registers~1--9 are also used
-for page identification: at shipout \TeX\ writes the values
-of these ten counters to the \n{dvi} file (see Chapter~\ref{TeXcomm}).
-Terminal and log file output display only the non-zero counters,
-and the zero counters for which a non-zero counter with
-a higher number exists, that is, if \cs{count0}${}=1$ and
-\cs{count3}${}=5$ are the only non-zero counters, the
-displayed list of counters is~\n{[1.0.0.5]}.
+
+除了 \cs{count0} ，计数器 ~1--9 也用于页码识别：在输出(shipout)时， \TeX\ 将这十个计数器的值写入 \n{dvi} 文件(见第~\ref{TeXcomm} 章)。终端和日志文件的输出仅显示非零的计数器，比如仅有 \cs{count0}${}=1$ 和
+\cs{count3}${}=5$ 时非零计数器，显示的列表为 \n{[1.0.0.5]} 。
+
 
 %\index{page!numbering|)}
 \index{page!numbering|)}
 
 %\subsection{Headlines and footlines in plain \TeX}
-\subsection{Headlines and footlines in plain \TeX}
+\subsection{plain \TeX 中的页眉页脚}
 
 %Plain \TeX\ has token lists \cs{headline} and
 %\cs{footline}; these are used in the macros
@@ -544,10 +499,9 @@ displayed list of counters is~\n{[1.0.0.5]}.
 %\begin{verbatim}
 %\vbox{\makeheadline\pagebody\makefootline}
 %\end{verbatim}
-Plain \TeX\ has token lists \cs{headline} and
-\cs{footline}; these are used in the macros
-\handbreak \cs{makeheadline} and \cs{makefootline}.
-The page is shipped out as (more or less)
+Plain \TeX\ 有记号列表 \cs{headline} 和
+\cs{footline}，它们用于 \cs{makeheadline} 和 \cs{makefootline} 宏中。页面大概以如下方式输出
+
 \begin{verbatim}
 \vbox{\makeheadline\pagebody\makefootline}
 \end{verbatim}
@@ -556,15 +510,15 @@ The page is shipped out as (more or less)
 %For non-standard headers and footers it is easier to
 %redefine the macros \cs{makeheadline} and \cs{makefootline}
 %than to tinker with the token lists.
-Both headline and footline are inserted inside a \cs{line}.
-For non-standard headers and footers it is easier to
-redefine the macros \cs{makeheadline} and \cs{makefootline}
-than to tinker with the token lists.
+
+页眉和页脚头以 \cs{line} 插入。对于非标准的页眉和页脚，可以通过重定义
+\cs{makeheadline} 和 \cs{makefootline} 来实现，好过处理记号列表。
+
 
 %%\spoint Example: no widow lines
 %\subsection{Example: no widow lines}
 %\spoint Example: no widow lines
-\subsection{Example: no widow lines}
+\subsection{举例：消除孤行}
 
 %Suppose that one does not want to allow widow lines,
 %but pages have in general no stretch or shrink,
@@ -572,12 +526,8 @@ than to tinker with the token lists.
 %A~solution would be to increase the page length
 %by one line if a page turns out to be broken
 %at a widow line.
-Suppose that one does not want to allow widow lines,
-but pages have in general no stretch or shrink,
-for instance because they only contain plain text.
-A~solution would be to increase the page length
-by one line if a page turns out to be broken
-at a widow line.
+假设要避免出现孤行的情况，但页面内又没有伸长或收缩粘连，比如因为仅含有普通文本，此时一个解决方法是让要在孤行处分页页面，增加一行高度。
+
 
 %\TeX's output routine can perform this sort of
 %trick: if the \cs{widowpenalty} is set to
@@ -587,14 +537,9 @@ at a widow line.
 %can temporarily increase the \cs{vsize}, and
 %let the page builder have another go at
 %finding a break point.
-\TeX's output routine can perform this sort of
-trick: if the \cs{widowpenalty} is set to
-some recognizable value, the output routine
-can see by the \cs{outputpenalty} if a widow
-line occurred. In that case, the output routine
-can temporarily increase the \cs{vsize}, and
-let the page builder have another go at
-finding a break point.
+
+\TeX 的输出例程可以执行此类技巧： 如果 \cs{widowpenalty} 设置为一些可以识别的值，那么输出程序可以通过 \cs{outputpenalty} 发现孤行。这种情况下，输出例程可以临时的增加 \cs{vsize}，然后让页面构建器重新寻找分页点。
+
 
 %Here is the skeleton of such an output routine.
 %No headers or footers are provided for.
@@ -602,7 +547,7 @@ finding a break point.
 %\newif\ifLargePage \widowpenalty=147
 %\newdimen\oldvsize \oldvsize=\vsize
 %\output={
-%    \ifLargePage \shipout\box255 
+%    \ifLargePage \shipout\box255
 %          \global\LargePagefalse
 %          \global\vsize=\oldvsize
 %    \else \ifnum \outputpenalty=\widowpenalty
@@ -617,13 +562,13 @@ finding a break point.
 %equals the \cs{widowpenalty}. The page box
 %is then \cs{unvbox}$\,$ed, so that the page builder
 %will tackle the same material once more.
-Here is the skeleton of such an output routine.
-No headers or footers are provided for.
+下面是这样一个输出例程的框架，其中没有提供页眉和页脚。
+
 \begin{verbatim}
 \newif\ifLargePage \widowpenalty=147
 \newdimen\oldvsize \oldvsize=\vsize
 \output={
-    \ifLargePage \shipout\box255 
+    \ifLargePage \shipout\box255
           \global\LargePagefalse
           \global\vsize=\oldvsize
     \else \ifnum \outputpenalty=\widowpenalty
@@ -633,25 +578,23 @@ No headers or footers are provided for.
           \else  \shipout\box255
     \fi   \fi}
 \end{verbatim}
-The test \cs{ifLargePage} is set to true by the
-output routine if the \cs{outputpenalty}
-equals the \cs{widowpenalty}. The page box
-is then \cs{unvbox}$\,$ed, so that the page builder
-will tackle the same material once more.
+
+如果 \cs{outputpenalty} 等于 \cs{widowpenalty} 时，\cs{ifLargePage} 将由输出例程设置为true。 然后页面盒子将解包(\cs{unvbox}$\,$ed)，所以页面构建器将重新处理一遍。
+
 
 %%\spoint Example: no indentation top of page
 %\subsection{Example: no indentation top of page}
 %\spoint Example: no indentation top of page
-\subsection{Example: no indentation top of page}
+\subsection{示例：消除页面顶部的缩进}
 
 %Some  output routines can be classified
 %\howto Prevent indentation on top of page\par
 %as abuse of the output routine mechanism.
 %The output routine in this section is a good example of this.
-Some  output routines can be classified
+一些输出例程可以定义为是对输出例程机制的滥用。
 \howto Prevent indentation on top of page\par
-as abuse of the output routine mechanism.
-The output routine in this section is a good example of this.
+本节中的输出例程就是这样一个例子：
+
 
 %It is imaginable that one wishes paragraphs not to indent
 %if they start at the top of a page. (There are plenty of objections
@@ -659,23 +602,17 @@ The output routine in this section is a good example of this.
 %This problem can be solved using the output routine to
 %investigate whether the page is still empty and, if so,
 %to give a signal that a paragraph should not indent.
-It is imaginable that one wishes paragraphs not to indent
-if they start at the top of a page. (There are plenty of objections
-to this layout, but occasionally it is used.)
-This problem can be solved using the output routine to
-investigate whether the page is still empty and, if so,
-to give a signal that a paragraph should not indent.
+
+可能有人希望页面顶部开始的段落不产生缩进。(尽管这种布局方式会有很多诟病的地方，但偶尔也会有这种需求)。这个问题可以通过输出例程来解决，检测页面是否还未空，如果是，则给出一个段落不缩进的信号。
+
 
 %Note that we cannot use the fact here
 %that the page builder comes into play after
 %the insertion of \cs{everypar}: even if we could
 %force the output routine to be activated here,
 %there is no way for it to remove the indentation box.
-Note that we cannot use the fact here
-that the page builder comes into play after
-the insertion of \cs{everypar}: even if we could
-force the output routine to be activated here,
-there is no way for it to remove the indentation box.
+注意，这里我们不能使用页面构建器会在 \cs{everypar} 插入后开始工作这一事实：即便我们可以强制输出例程在此处激活，也没有办法来移除缩进盒子。
+
 
 %The solution given here lets the \cs{everypar}
 %terminate the paragraph immediately
@@ -689,60 +626,54 @@ there is no way for it to remove the indentation box.
 %the output routine then can set a switch
 %signalling whether the retry of the paragraph
 %should indent.
-The solution given here lets the \cs{everypar}
-terminate the paragraph immediately
-with
+这里给出的解决方法是，设置 \cs{everypar} 立即结束段落：
+
 \begin{verbatim}
 \par\penalty-\specialpenalty
 \end{verbatim}
-which activates the output routine.
-Seeing whether the pagebox is empty (after removing
-the empty line and any \cs{parskip} glue),
-the output routine then can set a switch
-signalling whether the retry of the paragraph
-should indent.
+
+将会激活输出例程。观察页面盒子是否为空(在移除空行及任何 \cs{parskip} 粘连后)，输出例程可以设置一个转换信号，来再次确定段落是否缩进。
 
 %There are some minor matters in the following
 %routines, the sense of which is left
 %for the reader to ponder.
 %\begin{verbatim}
 %\mathchardef\specialpenalty=10001
-%\newif\ifPreventSwitch 
-%\newbox\testbox 
+%\newif\ifPreventSwitch
+%\newbox\testbox
 %\topskip=10pt
 
 %\everypar{\begingroup \par
 %    \penalty-\specialpenalty
-%    \everypar{\endgroup}\parskip0pt 
+%    \everypar{\endgroup}\parskip0pt
 %    \ifPreventSwitch \noindent \else \indent \fi
 %    \global\PreventSwitchfalse
 %    }
 %\output{
-%    \ifnum\outputpenalty=-\specialpenalty 
-%        \setbox\testbox\vbox{\unvbox255 
+%    \ifnum\outputpenalty=-\specialpenalty
+%        \setbox\testbox\vbox{\unvbox255
 %                  {\setbox0=\lastbox}\unskip}
 %        \ifdim\ht\testbox=0pt \global\PreventSwitchtrue
 %        \else \topskip=0pt \unvbox\testbox \fi
 %    \else \shipout\box255 \global\advance\pageno1 \fi}
 %\end{verbatim}
-There are some minor matters in the following
-routines, the sense of which is left
-for the reader to ponder.
+
+下面的例程中存在一些小的问题，原因留给读者思考：
 \begin{verbatim}
 \mathchardef\specialpenalty=10001
-\newif\ifPreventSwitch 
-\newbox\testbox 
+\newif\ifPreventSwitch
+\newbox\testbox
 \topskip=10pt
 
 \everypar{\begingroup \par
     \penalty-\specialpenalty
-    \everypar{\endgroup}\parskip0pt 
+    \everypar{\endgroup}\parskip0pt
     \ifPreventSwitch \noindent \else \indent \fi
     \global\PreventSwitchfalse
     }
 \output{
-    \ifnum\outputpenalty=-\specialpenalty 
-        \setbox\testbox\vbox{\unvbox255 
+    \ifnum\outputpenalty=-\specialpenalty
+        \setbox\testbox\vbox{\unvbox255
                   {\setbox0=\lastbox}\unskip}
         \ifdim\ht\testbox=0pt \global\PreventSwitchtrue
         \else \topskip=0pt \unvbox\testbox \fi
@@ -752,12 +683,12 @@ for the reader to ponder.
 %%\spoint More examples of output routines
 %\subsection{More examples of output routines}
 %\spoint More examples of output routines
-\subsection{More examples of output routines}
+\subsection{更多输出例程示例}
 
 %A large number of examples of output routines
 %can be found in~\cite{Sal1} and~\cite{Sal2}.
-A large number of examples of output routines
-can be found in~\cite{Sal1} and~\cite{Sal2}.
+在~\cite{Sal1} 和~\cite{Sal2} 中可以找到许多输出例程的示例。
+
 
 %\index{output routine|)}
 \index{output routine|)}

--- a/chapter29.tex
+++ b/chapter29.tex
@@ -89,8 +89,8 @@
 %      that started with \cs{topinsert}, \cs{midinsert},
 %      or \cs{pageinsert}.
 \item [\cs{endinsert}]
-      Plain \TeX\ 宏，以\cs{topinsert}, \cs{midinsert},
-      或 \cs{pageinsert} 方式处理插入项。
+      Plain \TeX\ 宏，结束以\cs{topinsert}, \cs{midinsert},
+      或 \cs{pageinsert} 开始的插入项。
 
 
 %\end{inventory}

--- a/chapter29.tex
+++ b/chapter29.tex
@@ -7,92 +7,91 @@
 \begin{document}
 
 %\chapter{Insertions}\label{insert}
-\chapter{Insertions}\label{insert}
+\chapter{插入}\label{insert}
 
 %Insertions are \TeX's way of handling floating information.
 %\TeX's page builder calculates what insertions and how many
 %of them will fit on the page; these insertion items are then
 %placed in insertion boxes which are to be handled by the
 %output routine.
-Insertions are \TeX's way of handling floating information.
-\TeX's page builder calculates what insertions and how many
-of them will fit on the page; these insertion items are then
-placed in insertion boxes which are to be handled by the
-output routine.
+
+插入是 \TeX 处理浮动信息的方法。 \TeX 的页面构建器首先需要计算插入什么内容、计算插入后占据页面的大小，然后把这些插入项放入插入盒子中，这些插入盒子将由输出例程(output routine)进一步处理。
 
 
 %\label{cschap:insert}\label{cschap:newinsert}\label{cschap:insertpenalties}\label{cschap:floatingpenalty}\label{cschap:holdinginserts}\label{cschap:footins}\label{cschap:topins}\label{cschap:topinsert}\label{cschap:pageinsert}\label{cschap:midinsert}\label{cschap:endinsert}
 %\begin{inventory}
-%\item [\cs{insert}] 
+%\item [\cs{insert}]
 %      Start an insertion item.
 \label{cschap:insert}\label{cschap:newinsert}\label{cschap:insertpenalties}\label{cschap:floatingpenalty}\label{cschap:holdinginserts}\label{cschap:footins}\label{cschap:topins}\label{cschap:topinsert}\label{cschap:pageinsert}\label{cschap:midinsert}\label{cschap:endinsert}
 \begin{inventory}
-\item [\cs{insert}] 
-      Start an insertion item.
+\item [\cs{insert}]
+      开始一个插入项。
 
-%\item [\cs{newinsert}] 
-%      Allocate a new insertion class. 
-\item [\cs{newinsert}] 
-      Allocate a new insertion class. 
+%\item [\cs{newinsert}]
+%      Allocate a new insertion class.
+\item [\cs{newinsert}]
+      分配一个新的插入类。
 
-%\item [\cs{insertpenalties}] 
+%\item [\cs{insertpenalties}]
 %      Total of penalties for split insertions.
 %      Inside the output routine, the number of held-over insertions.
-\item [\cs{insertpenalties}] 
-      Total of penalties for split insertions.
-      Inside the output routine, the number of held-over insertions.
+\item [\cs{insertpenalties}]
+      分割的插入项的总惩罚值。在输出例程内，则是延搁的插入项的数量。
 
-%\item [\cs{floatingpenalty}] 
+%\item [\cs{floatingpenalty}]
 %      Penalty added when an insertion is split.
-\item [\cs{floatingpenalty}] 
-      Penalty added when an insertion is split.
+\item [\cs{floatingpenalty}]
+      当一个插入项被分割出来时加入的惩罚值。
 
 %\item [\cs{holdinginserts}]
 %      (\TeX3 only)
-%      If this is positive, insertions are not placed in their boxes 
+%      If this is positive, insertions are not placed in their boxes
 %      at output time.
 \item [\cs{holdinginserts}]
-      (\TeX3 only)
-      If this is positive, insertions are not placed in their boxes 
-      at output time.
+      (仅 \TeX3 )如果是正值，在输出时，插入项将不会放入插入盒子中。
 
 %\item [\cs{footins}]
 %      Number of the footnote insertion class in plain \TeX.
 \item [\cs{footins}]
-      Number of the footnote insertion class in plain \TeX.
+      plain \TeX 中脚注插入类的数量。
+
 
 %\item [\cs{topins}]
 %      Number of the top insertion class.
 \item [\cs{topins}]
-      Number of the top insertion class.
+      顶部插入类的数量。
+
 
 %\item [\cs{topinsert}]
 %      Plain \TeX\ macro to start a top insert.
 \item [\cs{topinsert}]
-      Plain \TeX\ macro to start a top insert.
+      开始一个顶部插入的 Plain \TeX\ 宏。
+
 
 %\item [\cs{pageinsert}]
 %      Plain \TeX\ macro to start an insert that will take
 %      up a whole page.
 \item [\cs{pageinsert}]
-      Plain \TeX\ macro to start an insert that will take
-      up a whole page.
+      开始一个占据整个页面的插入的宏
+
+
 
 %\item [\cs{midinsert}]
 %      Plain \TeX\ macro that places its argument if there is space,
 %      and converts it into a top insert otherwise.
 \item [\cs{midinsert}]
-      Plain \TeX\ macro that places its argument if there is space,
-      and converts it into a top insert otherwise.
+      Plain \TeX\ 宏，当存在足够的空间时，用于在当前位置插入，否则将转换为顶部插入。
+
+
 
 %\item [\cs{endinsert}]
 %      Plain \TeX\ macro to wind up an insertion item
 %      that started with \cs{topinsert}, \cs{midinsert},
 %      or \cs{pageinsert}.
 \item [\cs{endinsert}]
-      Plain \TeX\ macro to wind up an insertion item
-      that started with \cs{topinsert}, \cs{midinsert},
-      or \cs{pageinsert}.
+      Plain \TeX\ 宏，以\cs{topinsert}, \cs{midinsert},
+      或 \cs{pageinsert} 方式处理插入项。
+
 
 %\end{inventory}
 \end{inventory}
@@ -101,7 +100,7 @@ output routine.
 %%\point Insertion items
 %\section{Insertion items}
 %\point Insertion items
-\section{Insertion items}
+\section{插入项}
 
 %Floating information, items that are not bound to a fixed
 %place in the vertical list, such as figures or footnotes,
@@ -109,20 +108,13 @@ output routine.
 %The treatment of insertions is a strange interplay between the
 %user, \TeX's internal workings, and the output routine.
 %First the user specifies an insertion, which is
-%a certain amount of vertical material; 
+%a certain amount of vertical material;
 %then \TeX's page builder decides what insertions should go
 %on the current page and puts these insertions in insertion boxes;
 %finally, the output routine has to do something with these boxes.
-Floating information, items that are not bound to a fixed
-place in the vertical list, such as figures or footnotes,
-are handled by \indexterm{insertions}.
-The treatment of insertions is a strange interplay between the
-user, \TeX's internal workings, and the output routine.
-First the user specifies an insertion, which is
-a certain amount of vertical material; 
-then \TeX's page builder decides what insertions should go
-on the current page and puts these insertions in insertion boxes;
-finally, the output routine has to do something with these boxes.
+
+浮动信息，是在竖直列中没有固定位置约束的项，由\indexterm{insertions} 处理，比如图片或者脚注。插入的处理受用户、 \TeX 内部规则、 输出例程的影响。首先，由用于引发一个插入，插入的内容是一定量的竖直内容。然后， \TeX 的页面构建器确定哪些插入项可以放入当前页面，然后将它们放到插入盒子中，最后输出例程来处理这些插入盒子。
+
 
 %An insertion item looks like
 %\cstoidx insert\par
@@ -130,30 +122,28 @@ finally, the output routine has to do something with these boxes.
 %\end{disp} where the 8-bit number should not be~255,
 %because \cs{box255} is used by \TeX\ for passing the page to the output
 %routine.
-An insertion item looks like
-\cstoidx insert\par
+
+一个插入项类似于:\cstoidx insert\par
+
 \begin{disp}\cs{insert}\gr{8-bit number}\lb\gr{vertical mode material}\rb
-\end{disp} where the 8-bit number should not be~255,
-because \cs{box255} is used by \TeX\ for passing the page to the output
-routine.
+\end{disp}
+
+其中，八比特数不能是255，因为\cs{box255}已经被\TeX\ 用来给输出传递页面内容。
 
 %The braces around the vertical mode material in an insertion
 %item can be implicit; they imply a new level of grouping.
 %The vertical mode material is processed in internal
 %vertical mode.
-The braces around the vertical mode material in an insertion
-item can be implicit; they imply a new level of grouping.
-The vertical mode material is processed in internal
-vertical mode.
 
-%Values of \cs{splittopskip}, \cs{splitmaxdepth}, 
+插入项中竖直模式内容外的花括号可以省略，它们表示新的一层编组。竖直模式内容在内部竖直模式中处理。
+
+
+%Values of \cs{splittopskip}, \cs{splitmaxdepth},
 %and \cs{floatingpenalty} are relevant for split insertions
 %(see below); the values that are current just before
 %the end of the group are used.
-Values of \cs{splittopskip}, \cs{splitmaxdepth}, 
-and \cs{floatingpenalty} are relevant for split insertions
-(see below); the values that are current just before
-the end of the group are used.
+\cs{splittopskip}, \cs{splitmaxdepth}, \cs{floatingpenalty}的值与插入项分割有关(见下面); 这些值仅在编组结束前使用。
+
 
 %Insertion items can appear in vertical mode, horizontal
 %mode, and math mode. For the latter two modes they have to
@@ -161,20 +151,16 @@ the end of the group are used.
 %(see page~\pageref{migrate}).
 %After an insertion item is put on  the vertical list the
 %page builder is exercised.
-Insertion items can appear in vertical mode, horizontal
-mode, and math mode. For the latter two modes they have to
-migrate to the surrounding vertical list
-(see page~\pageref{migrate}).
-After an insertion item is put on  the vertical list the
-page builder is exercised.
+
+插入项可以出现在竖直模式，水平模式，和数学模式中。对于后两者，插入项必须移入竖直列内(见~\pageref{migrate}页)。当插入项放入竖直列后，那么页面生成结束。
 
 
 %%\point Insertion class declaration
 %\section{Insertion class declaration}
 %\point Insertion class declaration
-\section{Insertion class declaration}
+\section{插入类声明}
 
-%In the plain format 
+%In the plain format
 %the  number for a new insertion class
 %is allocated by \csidx{newinsert}:
 %\begin{verbatim}
@@ -182,28 +168,27 @@ page builder is exercised.
 %\end{verbatim}
 %which uses \cs{chardef} to assign a number to the control
 %sequence.
-In the plain format 
-the  number for a new insertion class
-is allocated by \csidx{newinsert}:
+
+在 plain tex 中，一个插入类的号由 \csidx{newinsert} 分配:
+
 \begin{verbatim}
 \newinsert\myinsert % new insertion class
 \end{verbatim}
-which uses \cs{chardef} to assign a number to the control
-sequence.
+
+使用 \cs{chardef} 给控制序列赋一个号(数值)。
+
 
 %Insertion classes are allocated numbering from 254 downward.
 %As box~255 is used for output, this allocation scheme leaves
 %\cs{skip255}, \cs{dimen255}, and \cs{count255}
 %free for scratch use.
-Insertion classes are allocated numbering from 254 downward.
-As box~255 is used for output, this allocation scheme leaves
-\cs{skip255}, \cs{dimen255}, and \cs{count255}
-free for scratch use.
+插入类的号从254开始向下取值进行分配。因为 box~255 用于输出，这种方式也使得可以保留\cs{skip255}, \cs{dimen255}, \cs{count255} 待用。
+
 
 %%\point Insertion parameters
 %\section{Insertion parameters}
 %\point Insertion parameters
-\section{Insertion parameters}
+\section{插入参数}
 
 %For each insertion class~$n$ four registers are allocated:
 %\begin{itemize}
@@ -224,72 +209,62 @@ free for scratch use.
 % The value of \cs{count}$\,n$
 % is then 1000 times the factor by which the height should
 % be multiplied to obtain the effective height.
-% 
+%
 % Consider the following examples:
-% 
+%
 %\begin{itemize}\item Marginal notes do not affect
 % the text height, so the factor should be~0. \item Footnotes
 % set in double column mode affect the page by half of their height:
 % the count value should by~500. \item Conversely, footnotes
 % set at page width underneath a page in double column mode
 % affect both columns, so \ldash provided that the double column mode
-% is implemented by applying \cs{vsplit} to a double-height column \rdash 
+% is implemented by applying \cs{vsplit} to a double-height column \rdash
 % the count value should be~2000.\end{itemize}
 %\end{itemize}
-For each insertion class~$n$ four registers are allocated:
+
+对于每个插入类$n$，分配了四个寄存器:
+
 \begin{itemize}
-\item \cs{box}$\,n$ When the output routine is active this
- box contains the insertion items of class~$n$ that should
- be placed on the current page.
-\item \cs{dimen}$\,n$ This is the maximum space allotted for
- insertions of class~$n$ per page. If this amount would
- be exceeded \TeX\ will split insertions.
-\item \cs{skip}$\,n$ Glue of this size is added the first
- time an insertion item of class~$n$ is added to the
- current page. This is useful for such phenomena as a rule
- separating the footnotes from the text of the page.
-\item \cs{count}$\,n$ Each insertion item is a vertical list,
- so it has a certain height. However, the effective height,
- the amount of influence it has on the text height of the
- page, may differ from this real height.
- The value of \cs{count}$\,n$
- is then 1000 times the factor by which the height should
- be multiplied to obtain the effective height.
- 
- Consider the following examples:
- 
-\begin{itemize}\item Marginal notes do not affect
- the text height, so the factor should be~0. \item Footnotes
- set in double column mode affect the page by half of their height:
- the count value should by~500. \item Conversely, footnotes
- set at page width underneath a page in double column mode
- affect both columns, so \ldash provided that the double column mode
- is implemented by applying \cs{vsplit} to a double-height column \rdash 
- the count value should be~2000.\end{itemize}
+\item \cs{box}$\,n$ 当输出例程激活时，该box内包含有要插入当前页面的插入类$n$的内容。
+
+\item \cs{dimen}$\,n$ 这是每页能分配给插入类$n$的最大空间。当超越该值时，\TeX\ 将会分割插入内容。
+
+\item \cs{skip}$\,n$ 这一大小的粘连会在插入类~$n$的第一个项加入页面时被加入。它在一些情况下很有用，比如实现页面中脚注与正文见的分隔线。
+
+\item \cs{count}$\,n$ 每个插入项都是竖直列，所以它具有一定的高度。然而有效高度，即它对页面正文高度影响的量，可能不同于实际高度。\cs{count}$\,n$的值为
+    要获得有效高度，实际高度应乘上的因子再乘以1000的值。
+
+ 考虑如下例子:
+
+\begin{itemize}
+ \item 当边注不影响正文的高度，所以该因子为0。
+
+ \item 当脚注设置在双栏模式中，那么它仅影响页面的一半高度，那么计数器的值为500。
+
+ \item 相反的，当在双栏模式中设置单栏脚注，它将影响两栏的高度。假设两栏模式由\cs{vsplit} 分解为两倍高度的栏，那么计数器的值为2000。
+ \end{itemize}
 \end{itemize}
 
 %%\point Moving insertion items from the contributions list
 %\section{Moving insertion items from the contributions list}
 %\point Moving insertion items from the contributions list
-\section{Moving insertion items from the contributions list}
+\section{将插入项从备选竖直列中移出到当前页面}
 
 %The most complicated issue with insertions is the algorithm
 %that adds insertion items to the main vertical list,
 %and calculates breakpoints if necessary.
-The most complicated issue with insertions is the algorithm
-that adds insertion items to the main vertical list,
-and calculates breakpoints if necessary.
+插入中的最复杂的问题是将插入项加入主竖直列的算法以及必要时的分页计算。
+
 
 %\TeX\ never changes the \cs{vsize}, but it diminishes the
 %\csidx{pagegoal} by the (effective) heights of the insertion
 %items that will appear before a page break. Thus the output
 %routine will receive a \cs{box255} that has height \cs{pagegoal},
 %not necessarily \cs{vsize}.
-\TeX\ never changes the \cs{vsize}, but it diminishes the
-\csidx{pagegoal} by the (effective) heights of the insertion
-items that will appear before a page break. Thus the output
-routine will receive a \cs{box255} that has height \cs{pagegoal},
-not necessarily \cs{vsize}.
+\TeX\ 不改变 \cs{vsize}，
+但它会因为出现在分页前的插入项的(有效)高度而减小 \csidx{pagegoal}。
+因此输出例程接收的 \cs{box255} 的高度可能是\cs{pagegoal}，而不一定是\cs{vsize}。
+
 
 %\begin{enumerate}
 %\item When the first insertion of a certain class $n$ occurs
@@ -298,7 +273,7 @@ not necessarily \cs{vsize}.
 %  insertion item of this class occurs on the vertical list
 %  \ldash this includes insertions that were split \rdash  but \cs{box}$\,n$
 %  need not be empty at this time.
-%  
+%
 %  If \cs{box}$\,n$ is not empty, its height plus depth is multiplied
 %  by \cs{count}$\,n/1000$ and the result is subtracted
 %  from \cs{pagegoal}. Then the \cs{pagegoal} is diminished
@@ -311,13 +286,13 @@ not necessarily \cs{vsize}.
 %  \csidx{insertpenalties}. A~split insertion is an insertion item
 %  for which a breakpoint has been calculated as it will not
 %  fit on the current page in its entirety. Thus the insertion
-%  currently under consideration will certainly not wind up 
+%  currently under consideration will certainly not wind up
 %  on the current page.
 %\item After the preliminary action of the two previous points
 %  \TeX\ will place the actual insertion item on the main vertical
 %  list, at the end of the current contributions.
 %  First it will check whether the item will fit without being split.
-%  
+%
 %  There are two conditions to be checked:
 %\begin{itemize}\item
 %  adding the insertion item (plus all previous insertions of that class)
@@ -331,50 +306,36 @@ not necessarily \cs{vsize}.
 %  by the effective size of the insertion item, that is,
 %  by the height plus depth, multiplied by \cs{count}$n/1000$.
 \begin{enumerate}
-\item When the first insertion of a certain class $n$ occurs
-  on the current page \TeX\ has to account for the quantity
-  \cs{skip}$\,n$. This step is executed only if no earlier
-  insertion item of this class occurs on the vertical list
-  \ldash this includes insertions that were split \rdash  but \cs{box}$\,n$
-  need not be empty at this time.
-  
-  If \cs{box}$\,n$ is not empty, its height plus depth is multiplied
-  by \cs{count}$\,n/1000$ and the result is subtracted
-  from \cs{pagegoal}. Then the \cs{pagegoal} is diminished
-  by the natural component of \cs{skip}$\,n$. Any stretch and
-  shrink of \cs{skip}$\,n$ are incorporated in \cs{pagestretch}
-  and \cs{pageshrink} respectively.
-\item If there is a split insertion of class $n$ on the page
-  \ldash this case and the previous step in the algorithm are
-  mutually exclusive \rdash  the \csidx{floatingpenalty} is added to
-  \csidx{insertpenalties}. A~split insertion is an insertion item
-  for which a breakpoint has been calculated as it will not
-  fit on the current page in its entirety. Thus the insertion
-  currently under consideration will certainly not wind up 
-  on the current page.
-\item After the preliminary action of the two previous points
-  \TeX\ will place the actual insertion item on the main vertical
-  list, at the end of the current contributions.
-  First it will check whether the item will fit without being split.
-  
-  There are two conditions to be checked:
-\begin{itemize}\item
-  adding the insertion item (plus all previous insertions of that class)
-  to \cs{box}$\,n$ should not let
-  the height plus depth of that box exceed \cs{dimen}$\,n$, and
-  \item either the effective height of the insertion is negative, or
-  \cs{pagetotal} plus \cs{pagedepth} minus \cs{pageshrink}
-  plus the effective size of the insertion should be less than
-  \cs{pagegoal}.\end{itemize}
-  If these conditions are satisfied, \cs{pagegoal} is diminished
-  by the effective size of the insertion item, that is,
-  by the height plus depth, multiplied by \cs{count}$n/1000$.
+\item 当一个插入类$n$的第一个插入项插入当前页面时， \TeX\  必须考虑 \cs{skip}$\,n$ 的量。这一步骤仅在该插入类没有更早的插入项插入主竖直列时执行，包括哪些分割出来的插入项，此时 \cs{box}$\,n$ 不一定是空的。
+
+    如果 \cs{box}$\,n$ 不为空，它的高度加深度乘以\cs{count}$\,n/1000$得到一个结果，
+    \cs{pagegoal} 减去该结果。接着 \cs{pagegoal} 再减去\cs{skip}$\,n$的自然高度。任何伸长和收缩都各自合并在\cs{pagestretch}和\cs{pageshrink}中。
+
+\item 如果当前页面存在插入类$n$中分割出的插入项，这一情况与上一步的情况正好相反，则将
+ \csidx{floatingpenalty}加入 \csidx{insertpenalties}。一个分割出的插入项指的是当完整的插入无法在当前页面实现时计算出断点后分割的项。因此，剩下的插入项必然不会在当前页面考虑插入。
+
+
+\item 在上面两步的操作后，\TeX\  将把实际插入项放入主竖直列，在当前页面的末尾。首先它将检查插入项是否不经分割就能放入。
+
+需要检测两种情况:
+\begin{itemize}
+
+\item 把当前插入项加上所有前面同一插入类的插入项放入 \cs{box}$\,n$ 后，其高度加深度不应超过\cs{dimen}$\,n$。
+
+
+  \item 插入项的有效高度为负或者\cs{pagetotal} 加上 \cs{pagedepth} 减去
+  \cs{pageshrink} 加上插入项的有效高度应小于 \cs{pagegoal}
+
+\end{itemize}
+  如果这些条件满足，那么\cs{pagegoal}减去插入项的有效尺寸，即高度加深度乘以
+  \cs{count}$n/1000$。
+
 
 %\item Insertions that fail on one of the two conditions in the
 %  previous step of the algorithm will be considered for splitting.
-%  \TeX\ will calculate the size of the maximal portion to 
+%  \TeX\ will calculate the size of the maximal portion to
 %  be split off the insertion item, such that
-%  
+%
 %\begin{enumerate}\item adding this portion
 %  together with earlier insertions of this class to \cs{box}$\,n$
 %  will not let the size of the box exceed \cs{dimen}$\,n$,
@@ -383,35 +344,27 @@ not necessarily \cs{vsize}.
 %  exceed \cs{pagegoal}. Note that \cs{pageshrink} is not taken
 %  into account this time, as it was in the previous step.
 %  \end{enumerate}
-%  
+%
 %  Once this maximal size to be split off has been determined,
-%  \TeX\ locates the least-cost breakpoint in the current 
+%  \TeX\ locates the least-cost breakpoint in the current
 %  insertion item that will result in a box with a  height
 %  that is equal to this maximal size. The penalty associated
 %  with this breakpoint is added to \cs{insertpenalties},
 %  and \cs{pagegoal} is diminished by the effective height plus
 %  depth of the box to be split off the insertion item.
-\item Insertions that fail on one of the two conditions in the
-  previous step of the algorithm will be considered for splitting.
-  \TeX\ will calculate the size of the maximal portion to 
-  be split off the insertion item, such that
-  
-\begin{enumerate}\item adding this portion
-  together with earlier insertions of this class to \cs{box}$\,n$
-  will not let the size of the box exceed \cs{dimen}$\,n$,
-  and \item the effective size of this portion,
-  added to \cs{pagetotal} plus \cs{pagedepth}, will not
-  exceed \cs{pagegoal}. Note that \cs{pageshrink} is not taken
-  into account this time, as it was in the previous step.
+\item 当算法前一步两个条件不满足时，插入项需要考虑分割。 \TeX\ 将计算分割出的最大部分的尺寸，使得:
+
+
+\begin{enumerate}
+\item 将这一分割部分加上之前的同一插入类的插入项放入 \cs{box}$\,n$ 后，盒子的尺寸不会超过\cs{dimen}$\,n$。
+
+
+  \item 这一部分的有效尺寸加上\cs{pagetotal}和\cs{pagedepth}，不会超过\cs{pagegoal}。注意此时不考虑 \cs{pageshrink} 因为它已在前面的步骤中处理。
+
   \end{enumerate}
-  
-  Once this maximal size to be split off has been determined,
-  \TeX\ locates the least-cost breakpoint in the current 
-  insertion item that will result in a box with a  height
-  that is equal to this maximal size. The penalty associated
-  with this breakpoint is added to \cs{insertpenalties},
-  and \cs{pagegoal} is diminished by the effective height plus
-  depth of the box to be split off the insertion item.
+
+  一旦确定了最大的分割尺寸， \TeX\  将在当前插入项中定位一个最低开销的断点，使得盒子中的高度等于最大的尺寸。与该断点相关的惩罚将加入\cs{insertpenalties}，\cs{pagegoal} 将减去分割出来的插入项的盒子的有效尺寸即高度加深度。
+
 
 %\end{enumerate}
 \end{enumerate}
@@ -421,7 +374,7 @@ not necessarily \cs{vsize}.
 %%\point Insertions in the output routine
 %\section{Insertions in the output routine}
 %\point Insertions in the output routine
-\section{Insertions in the output routine}
+\section{在输出例程中插入}
 
 %When the output routine comes into action \ldash more precisely:
 %when \TeX\ starts processing the tokens in the \cs{output}
@@ -429,12 +382,9 @@ not necessarily \cs{vsize}.
 %current page have been put in their boxes, and
 %it is the responsibility of the output routine
 %to put them somewhere in the box that is going to be shipped out.
-When the output routine comes into action \ldash more precisely:
-when \TeX\ starts processing the tokens in the \cs{output}
-token list \rdash  all insertions that should be placed on the
-current page have been put in their boxes, and
-it is the responsibility of the output routine
-to put them somewhere in the box that is going to be shipped out.
+
+当输出例程开始工作 \ldash 更准确的说，当 \TeX\ 开始处理 \cs{output} 中的记号列  \rdash  所有本页的插入项将被放入它们所在盒子，输出列程负责将它们放置在合适的位置，等待进一步输出。
+
 
 %\begin{example} The plain \TeX\ output routine
 %handles top inserts and footnotes by packaging the following
@@ -447,16 +397,17 @@ to put them somewhere in the box that is going to be shipped out.
 %Unboxing the insertion boxes makes the glue on various parts
 %of the page stretch or shrink in a uniform manner.
 %\end{example}
-\begin{example} The plain \TeX\ output routine
-handles top inserts and footnotes by packaging the following
-sequence:
+\begin{example}
+plain \TeX\ 输出例程以如下顺序来打包处理顶部插入和脚注：
+
 \begin{verbatim}
 \ifvoid\topins \else \unvbox\topins \fi
 \pagebody
 \ifvoid\footins \else \unvbox\footins \fi
 \end{verbatim}
-Unboxing the insertion boxes makes the glue on various parts
-of the page stretch or shrink in a uniform manner.
+
+解包插入的盒子是的页面中不同位置的粘连以统一的方式伸长和收缩。
+
 \end{example}
 
 %With \TeX3 the insertion mechanism has been extended slightly:
@@ -468,15 +419,14 @@ of the page stretch or shrink in a uniform manner.
 %recalculate the \cs{vsize}, or if the output routine
 %is called to do other intermediate calculations instead of
 %ejecting a page.
-With \TeX3 the insertion mechanism has been extended slightly:
+
+\TeX3 稍微扩展了插入机制：
 \handbreak \cstoidx holdinginserts\par
 \thecstoidxsub{TeX}{version 3}
-the parameter \cs{holdinginserts} can be used to specify that
-insertions should not yet be placed in their boxes.
-This is very useful if the output routine wants to
-recalculate the \cs{vsize}, or if the output routine
-is called to do other intermediate calculations instead of
-ejecting a page.
+参数 \cs{holdinginserts} 可以用来设置不将插入项放入它们的盒子。
+当输出例程需要重新计算 \cs{vsize} 或者输出例程被调用来做其它中间计算而不是输出一个页面时，这一机制会非常有用。
+
+
 
 %During the output routine the parameter
 %\csidx{insertpenalties} holds the number of insertion items that
@@ -484,17 +434,15 @@ ejecting a page.
 %In the plain \TeX\ output routine this is used after the
 %last page:
 %\begin{verbatim}
-%\def\dosupereject{\ifnum\insertpenalties>0 
+%\def\dosupereject{\ifnum\insertpenalties>0
 %    % something is being held over
 %  \line{}\kern-\topskip\nobreak\vfill\supereject\fi}
 %\end{verbatim}
-During the output routine the parameter
-\csidx{insertpenalties} holds the number of insertion items that
-are being held over for the next page.
-In the plain \TeX\ output routine this is used after the
-last page:
+
+在输出过程中，参数 \csidx{insertpenalties} 保存有将在下一页处理的插入项的数量。在 plain \TeX\ 中它将在前一页处理后用到：
+
 \begin{verbatim}
-\def\dosupereject{\ifnum\insertpenalties>0 
+\def\dosupereject{\ifnum\insertpenalties>0
     % something is being held over
   \line{}\kern-\topskip\nobreak\vfill\supereject\fi}
 \end{verbatim}
@@ -502,7 +450,7 @@ last page:
 %%\point Plain \TeX\ insertions
 %\section{Plain \TeX\ insertions}
 %\point Plain \TeX\ insertions
-\section{Plain \TeX\ insertions}
+\section{Plain \TeX\ 的插入}
 
 %The plain \TeX\ format has only two insertion classes:
 %the footnotes and the top inserts.
@@ -511,36 +459,31 @@ last page:
 %The \csidx{midinsert} macro tests whether the vertical material
 %specified by the user fits on the page; if so, it is placed
 %there; if not, it is converted to a top insert.
-The plain \TeX\ format has only two insertion classes:
-the footnotes and the top inserts.
-The macro \csidx{pageinsert} generates
-top inserts that are stretched to be exactly \cs{vsize} high.
-The \csidx{midinsert} macro tests whether the vertical material
-specified by the user fits on the page; if so, it is placed
-there; if not, it is converted to a top insert.
+
+plain \TeX\ 格式只有两种插入类：脚注和顶部插入。
+\csidx{pageinsert} 宏产生一个精确伸长至\cs{vsize}高度的顶部插入。
+\csidx{midinsert} 宏判断用户设定插入的竖直盒子是否能够插入当前页，如果可以，则放入当前，否则，将其转换为一个顶部插入(top insert)。
+
 
 %Footnotes are allowed to be split, but once one has been
 %split no further footnotes should appear on the current
-%page. This effect is attained by setting 
+%page. This effect is attained by setting
 %\begin{verbatim}
 %\floatingpenalty=20000
-%\end{verbatim} 
+%\end{verbatim}
 %The \cs{floatingpenalty} is added to \cs{insertpenalties}
-%if an insertion follows a split insertion of the same 
+%if an insertion follows a split insertion of the same
 %class. However, \cs{floatingpenalty}${}>10\,000$ has infinite
 %cost, so \TeX\ will take an earlier breakpoint for
 %splitting off the page from the vertical list.
-Footnotes are allowed to be split, but once one has been
-split no further footnotes should appear on the current
-page. This effect is attained by setting 
+脚注允许分割，但一旦分割，后面的的脚注将不会出现在当前页。这样机制由如下设置得到：
+
 \begin{verbatim}
 \floatingpenalty=20000
-\end{verbatim} 
-The \cs{floatingpenalty} is added to \cs{insertpenalties}
-if an insertion follows a split insertion of the same 
-class. However, \cs{floatingpenalty}${}>10\,000$ has infinite
-cost, so \TeX\ will take an earlier breakpoint for
-splitting off the page from the vertical list.
+\end{verbatim}
+
+如果一个插入项紧跟着同类的分割插入项，那么 \cs{floatingpenalty} 将被加入到 \cs{insertpenalties}中。然而 \cs{floatingpenalty}${}>10\,000$ 具有无限的代价，所以 \TeX\ 会从一个更早的分页点将页面从竖直列分割出来。
+
 
 %Top inserts essentially contain only a vertical box
 %which holds whatever the user specified. Thus such an insert
@@ -551,20 +494,13 @@ splitting off the page from the vertical list.
 %the next page. As the \cs{floatingpenalty} for top inserts
 %is zero, arbitrarily many of these inserts can be moved forward
 %until there is a page with sufficient space.
-Top inserts essentially contain only a vertical box
-which holds whatever the user specified. Thus such an insert
-cannot be split. However, the \csidx{endinsert} macro
-puts a \cs{penalty100} on top of the box, so the
-insertion can be split with an empty part before the split.
-The effect is that the whole insertion is carried over to
-the next page. As the \cs{floatingpenalty} for top inserts
-is zero, arbitrarily many of these inserts can be moved forward
-until there is a page with sufficient space.
+
+顶部插入基本上仅包含一个竖直盒子，该盒子中保存用户设定的任何内容。因此，这种插入项不能被分割。然而，\csidx{endinsert} 宏将一个 \cs{penalty100} 放在盒子顶部，所以该插入项可以在分割点前分割出一个空的部分。效果是整个插入项监视移动到下一页。因为顶部插入的 \cs{floatingpenalty} 为0，任意数量的插入项都可以不断向前移动直到找到空间足够的页面。
+
 
 %Further examples of insertion macros can be found
 %in~\cite{Sal3}.
-Further examples of insertion macros can be found
-in~\cite{Sal3}.
+更多插入宏的示例见~\cite{Sal3}。
 
 %%\message{Maybe spaceleft example?}
 %\message{Maybe spaceleft example?}


### PR DESCRIPTION

最近在思考实现一个宏包，所以看的tex内容较多，顺便把它们翻译出来了。术语与已有内容保持基本统一，比如页面构建器，备选内容，主竖直列等等。

想写一个宏包，其实是很早之前的想法，最近准备开始实施了。
目的是实现一个版心内的注。即把注不放到页脚，也不放到页边，而是放到版心内，(严格说脚注也在版心内，但它已经不属于正文那部分了)。
比如当前页正文行文中插入\textnote{《春晓》，唐诗，作者孟浩然}，然后在当前页面版心右下角占据一半行宽的栏内放入这一注的内容。

布局形式上这可以称为文注混排，有点像图文混排，可以把放注的盒子看做混排的图。又有点像局部的双栏，或双栏语言对照或者代码效果对照，这里可以参考wrapfig，multicol，paralist等。如果放注的盒子的位置没有强制要求，比如直接在注所在段落旁边，那么这种形式，参考上述宏包，利用tex的段落形状的机制应该就可以实现。

但如果要强制要求盒子的位置，比如一定要放到页面版心底部，那么就需要考虑实现的机制。首先想到的是类似浮动体的机制，利用insertion，可以向脚注或者浮动体的一样，在版心底部插入，但这个时候插入的盒子是完全占满整个行空间的，也就是无法体现出文注混排的形式。难点在这里。

要求将放注的盒子在版心底部一侧占据一定的空间，而正文在其左侧正常排，这种情况还可以用另外一种思路来实现，就是利用页面布局，如果存在非矩形的版心布局，而是矩形缺一角(这一角在底部是一个小矩形)的布局，那么正文正常排版，而把注独立出来，利用页面的定位，把它放入小矩形所在位置即可，但是目前还没有缺一角这种页面布局的方法。而且每一页注的大小可能不一样，所以全局的设置页面布局也存在问题。

页面布局不容易实现，那么只能考虑用类似浮动体的方法，而且需要改进。想象一下，把注的内容作为一个插入项，计算其盒子的尺寸并记录。如果这个盒子占据一半的行宽，假设盒子的宽为w，高为h，那么插入页面后，实际影响页面的高度为h，但是影响正文排版的高度为0，只是影响了正文h高度的行宽。如果这是一个浮动体，那么将影响h高度的内容即影响h*2w的文字内容，将这一部分内容移除，留出高度h的空间插入即可。但现在仅需要移除一半，因为剩下的一半还需要排h/2高的页面空间(需要排成h*w)。现在的思路是把h/2的内容取出来，做一半行宽段落形状，然后在其旁边插入放注的盒子。所以这里涉及到分页的机制，插入的机制，以及tex的逻辑，不知道能否实现，如果有些机制利用不起来，估计都实现不了。所以我想顺便放出来讨论一下。


